### PR TITLE
Guard for not allowing to see component details on a non-existing component

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,11 +2,13 @@ import { Routes } from '@angular/router';
 import { LandingComponent } from './components/landing/landing.component';
 import { SidebarComponent } from './components/component-view/sidebar/sidebar.component';
 import { ComponentViewComponent } from './components/component-view/component-view.component';
+import { componentViewGuard } from './guards/component-view.guard';
 
 export const routes: Routes = [
     {
         path: 'components/:name/:showedInfo',
         component: ComponentViewComponent,
+        canActivate: [componentViewGuard]
     },
     { path: '**', component: LandingComponent },
 ];

--- a/src/app/guards/component-view.guard.spec.ts
+++ b/src/app/guards/component-view.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { componentViewGuard } from './component-view.guard';
+
+describe('componentViewGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => componentViewGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/guards/component-view.guard.ts
+++ b/src/app/guards/component-view.guard.ts
@@ -1,0 +1,16 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { ComponentsInfoService } from '../services/components-info.service';
+
+export const componentViewGuard: CanActivateFn = (route, state) => {
+  const componentNameInUrl = route.params['name'];
+  const componentsInfoService = inject(ComponentsInfoService);
+  const found = componentsInfoService.getComponentMinInfo(componentNameInUrl);
+  if (found) {
+    return true;
+  } else {
+    const router = inject(Router);
+    router.navigate(['/not-found']);
+    return false;
+  }
+};


### PR DESCRIPTION
Guard that redirects to /not-found when the component doesn't exist (component-view component)